### PR TITLE
Added a "Log" property option

### DIFF
--- a/tasks/revision.js
+++ b/tasks/revision.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
           }
 
           grunt.log.writeln('LOG: ' + result.toString());
-          grunt.config(options.property.log, result);
+          grunt.config(options.property.log, result.toString());
           done(true);
         });
       } else {

--- a/tasks/revision.js
+++ b/tasks/revision.js
@@ -51,6 +51,7 @@ module.exports = function(grunt) {
           }
 
           grunt.log.writeln('LOG: ' + result.toString());
+          grunt.config(options.property.log, result);
           done(true);
         });
       } else {

--- a/tasks/revision.js
+++ b/tasks/revision.js
@@ -11,7 +11,10 @@
 module.exports = function(grunt) {
   grunt.registerTask('revision', 'Retrieves the current git revision', function(property) {
     var options = this.options({
-      property: 'meta.revision',
+      property: {
+        version: 'meta.revision',
+        log: 'meta.log',
+      },
       ref: 'HEAD',
       short: true
     });
@@ -30,10 +33,28 @@ module.exports = function(grunt) {
 
       var revision = result.toString();
 
-      grunt.config(options.property, revision);
+      if(typeof options.property === 'string'){
+        grunt.config(options.property, revision);
+      } else {
+        grunt.config(options.property.version, revision);
+      }
       grunt.log.writeln(options.ref + ' at revision ' + revision);
+      // Also pull in the log version
+      if(options.property.log){
+        grunt.util.spawn({
+          cmd: 'git',
+          args: ['rev-parse', options.short && '--short', options.ref].filter(Boolean)
+        }, function(err, result) {
+          if (err) {
+            grunt.log.error(err);
+            return done(false);
+          }
 
-      done(true);
+          done(true);
+        });
+      } else {
+        done(true);
+      }
     });
   });
 };

--- a/tasks/revision.js
+++ b/tasks/revision.js
@@ -43,13 +43,14 @@ module.exports = function(grunt) {
       if(options.property.log){
         grunt.util.spawn({
           cmd: 'git',
-          args: ['rev-parse', options.short && '--short', options.ref].filter(Boolean)
+          args: ['log', '-1', '--pretty=%B', options.ref].filter(Boolean)
         }, function(err, result) {
           if (err) {
             grunt.log.error(err);
             return done(false);
           }
 
+          grunt.log.writeln('LOG: ' + result.toString());
           done(true);
         });
       } else {


### PR DESCRIPTION
This option allows you to specify returning a "log" option as well, so you can provide both the revision number AND the commit message.
